### PR TITLE
Specify all authors in README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024 Ludvig Larsson, KTH-SSAS
+Copyright (c) 2024 Ludvig Larsson, Nikolaos Kakouros, Benjamin Kelley
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ work on macOS and Linux (images: `macOS-latest` and `ubuntu-24.04`).
 Note: Testing requires `openvpn >= 2.6` since the used `peer-fingerprint`
 feature was first introduced then.
 
+## Authors
+- Ludvig Larsson - lular@kth.se
+- Nikolaos Kakouros - nkak@kth.se
+- Benjamin Kelley - bekelley@kth.se
+
 ## Command line usage
 ```bash
 # connect

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "python-openvpn-client"
 version = "0.0.1"
-authors = [{ name = "Ludvig Larsson", email = "ludvig19@icloud.com" }]
+authors = [
+    { name = "Ludvig Larsson", email = "lular@kth.se" },
+    { name = "Nikolaos Kakouros", email = "nkak@kth.se" },
+    { name = "Benjamin Kelley", email = "bekelley@kth.se" },
+]
+
 description = "An API for managing an OpenVPN connection"
 readme = "README.md"
 requires-python = ">=3.9" # via 'vermin'


### PR DESCRIPTION
PyPi doesn't support multiple authors so the complete list is placed in the README file.